### PR TITLE
feat: add rows per page limit to pagination and table components

### DIFF
--- a/docs/.vuepress/components/TableWithRemotePagination.vue
+++ b/docs/.vuepress/components/TableWithRemotePagination.vue
@@ -44,6 +44,10 @@ export default {
         page(currentPage) {
             this.fetchRows(currentPage, this.rowsPerPage)
         },
+
+        rowsPerPage(limit) {
+            this.fetchRows(this.page, limit)
+        },
     },
 
     mounted() {

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -17,7 +17,6 @@ The select component is a lightweight extension of the standard select element, 
 | label       | `String`                 | `'Please select an option'` | Defines the text to display on the select component. Defaults to static text when no option is selected, otherwise uses the option name as the label.            |
 | value       | `Object\|Number\|String` | `null`                      | Defines the value of the select component.                                                                                                                       |
 | options     | `Array`                  | `[]`                        | Defines the options to display when select is opened.                                                                                                            |
-| option-key  | `String`                 | `'key'`                     | Defines the key identifier of the option.                                                                                                                        |
 | option-name | `String`                 | `'name'`                    | Defines the name of the option that will be displayed as the option text and displayed as the value of the select when the option is selected.                   |
 
 ### Events

--- a/src/components/Pagination/index.scss
+++ b/src/components/Pagination/index.scss
@@ -34,7 +34,8 @@
 	&-pages {
 		display: flex;
 
-		.go-to-previous-page {
+		.go-to-previous-page,
+		.mr-select-container {
 			margin-right: 8px;
 		}
 

--- a/src/components/Pagination/index.vue
+++ b/src/components/Pagination/index.vue
@@ -14,6 +14,14 @@
 		</div>
 
 		<div class="mr-pagination-pages flex align-items-center">
+			<Select
+				size="sm"
+				class="row-limit-per-page"
+				:model-value="limit"
+				:options="limitOptions"
+				@update:model-value="updateLimit"
+			/>
+
 			<Button
 				size="sm"
 				theme="text-solid"
@@ -48,12 +56,14 @@
 
 <script>
 import Button from '../Button/index.vue'
+import Select from '../Select/index.vue'
 import Icon from '../Icon/index.vue'
 
 export default {
 	components: {
 		Icon,
 		Button,
+		Select
 	},
 
 	props: {
@@ -89,6 +99,10 @@ export default {
 		totalPages() {
 			return Math.ceil(this.totalCount / this.limit)
 		},
+
+		limitOptions() {
+			return [10, 25, 50, 100]
+		}
 	},
 
 	methods: {
@@ -99,6 +113,10 @@ export default {
 		goToPreviousPage() {
 			this.$emit('update:page', this.page - 1)
 		},
+
+		updateLimit(limit) {
+			this.$emit('update:limit', limit)
+		}
 	},
 }
 </script>

--- a/src/components/Select/index.scss
+++ b/src/components/Select/index.scss
@@ -8,7 +8,7 @@
 $sizes: (
 	'sm': (
 		'font-size': 11px,
-		'line-height': 18px,
+		'line-height': 12px,
 		'padding': 0.5rem 0.8rem,
 	),
 	'md': (
@@ -55,6 +55,7 @@ $sizes: (
 
 			.mr-icon {
 				padding-top: 2px;
+				padding-left: map.get($sizeValues, 'font-size') - 5px;
 				font-size: map.get($sizeValues, 'font-size') + 4px;
 			}
 		}

--- a/src/components/Select/index.vue
+++ b/src/components/Select/index.vue
@@ -26,7 +26,7 @@
 					:class="{selected: currentValue === option}"
 					@click="currentValue = option"
 				>
-					{{ option[optionName] }}
+					{{ option[optionName] ? option[optionName] : option }}
 				</li>
 			</ul>
 		</transition>
@@ -80,11 +80,6 @@ export default {
 		options: {
 			type: Array,
 			default: () => []
-		},
-
-		optionKey: {
-			type: String,
-			default: "key"
 		},
 
 		optionName: {

--- a/src/components/Table/index.vue
+++ b/src/components/Table/index.vue
@@ -126,7 +126,7 @@
 			<Pagination
 				v-if="hasPagination"
 				v-model:page="currentPage"
-				:limit="limit"
+				v-model:limit="limit"
 				:total-count="totalRows"
 			/>
 

--- a/tests/unit/components/Pagination/index.spec.js
+++ b/tests/unit/components/Pagination/index.spec.js
@@ -82,5 +82,28 @@ describe('Pagination', () => {
 			expect(wrapper.emitted()['update:page']).toBeTruthy()
 			expect(wrapper.emitted()['update:page'][0]).toEqual([2])
 		})
+
+		it('shows the rows per page select limiter', () => {
+			const rowsPerPageSelect = wrapper.findComponent('.row-limit-per-page')
+
+			expect(rowsPerPageSelect.exists()).toBeTruthy()
+		})
+
+		it('has valid rows per page limit options', () => {
+			const limitsConfigured = wrapper.vm.limitOptions
+
+			expect(limitsConfigured.length).toBe(4)
+			expect(limitsConfigured).toContain(10)
+			expect(limitsConfigured).toContain(25)
+			expect(limitsConfigured).toContain(50)
+			expect(limitsConfigured).toContain(100)
+		})
+
+		it('updates the rows per page limit', async () => {
+			await wrapper.vm.updateLimit(25)
+
+			expect(wrapper.emitted('update:limit'))
+			expect(wrapper.emitted('update:limit')[0][0]).toBe(25)
+		})
 	})
 })


### PR DESCRIPTION
## Description:

Fixes: #22 

## What are the expected visible changes:

A select box will appear in the pagination component, containing the options: 10, 25, 50 and 100. This will also appear in the tables that have pagination enabled.

#### TODO:

-   [x] Implementation
-   [x] Unit tests
-   [x] Documentation
