### PR TITLE
feat: add loading state to button component

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -17,6 +17,7 @@ The button component is a lightweight extension of the standard HTML button, sup
 | icon          | `String`  | `''`        | Defines the icon to render inside the Button                                                                                                              |
 | icon-position | `String`  | `'start'`   | Defines where the icon should be placed. Possible values are: `start` and `end`                                                                           |
 | disabled      | `Boolean` | `false`     | Defines if the button should be disabled or not                                                                                                           |
+| loading       | `Boolean` | `false`     | Defines if the button should be in loading mode or not                                                                                                    |
 
 ## Basic Button
 
@@ -290,6 +291,94 @@ Besides themes and sizes, every button can define a set of props to control thei
 	<Button disabled theme="text-solid" variant="warning">Warning</Button>
 	<Button disabled theme="text-solid" variant="success">Success</Button>
 	<Button disabled theme="text-solid" variant="info">Info</Button>
+</template>
+```
+
+  </CodeGroupItem>
+</CodeGroup>
+
+### Loading
+
+<p class="components-inline">
+    <Button loading>Default</Button>
+    <Button loading variant="primary">Primary</Button>
+    <Button loading variant="secondary">Secondary</Button>
+    <Button loading variant="danger">Danger</Button>
+    <Button loading variant="warning">Warning</Button>
+    <Button loading variant="success">Success</Button>
+    <Button loading variant="info">Info</Button>
+</p>
+
+<p class="components-inline">
+    <Button loading theme="outlined">Default</Button>
+    <Button loading theme="outlined" variant="primary">Primary</Button>
+    <Button loading theme="outlined" variant="secondary">Secondary</Button>
+    <Button loading theme="outlined" variant="danger">Danger</Button>
+    <Button loading theme="outlined" variant="warning">Warning</Button>
+    <Button loading theme="outlined" variant="success">Success</Button>
+    <Button loading theme="outlined" variant="info">Info</Button>
+</p>
+
+<p class="components-inline">
+    <Button loading theme="text">Default</Button>
+    <Button loading theme="text" variant="primary">Primary</Button>
+    <Button loading theme="text" variant="secondary">Secondary</Button>
+    <Button loading theme="text" variant="danger">Danger</Button>
+    <Button loading theme="text" variant="warning">Warning</Button>
+    <Button loading theme="text" variant="success">Success</Button>
+    <Button loading theme="text" variant="info">Info</Button>
+</p>
+
+<p class="components-inline">
+    <Button loading theme="text-solid">Default</Button>
+    <Button loading theme="text-solid" variant="primary">Primary</Button>
+    <Button loading theme="text-solid" variant="secondary">Secondary</Button>
+    <Button loading theme="text-solid" variant="danger">Danger</Button>
+    <Button loading theme="text-solid" variant="warning">Warning</Button>
+    <Button loading theme="text-solid" variant="success">Success</Button>
+    <Button loading theme="text-solid" variant="info">Info</Button>
+</p>
+
+<CodeGroup>
+  <CodeGroupItem title="Vue" active>
+
+```vue
+<template>
+	<!-- Solid -->
+	<Button loading>Default</Button>
+	<Button loading variant="primary">Primary</Button>
+	<Button loading variant="secondary">Secondary</Button>
+	<Button loading variant="danger">Danger</Button>
+	<Button loading variant="warning">Warning</Button>
+	<Button loading variant="success">Success</Button>
+	<Button loading variant="info">Info</Button>
+
+	<!-- Outlined -->
+	<Button loading theme="outlined">Default</Button>
+	<Button loading theme="outlined" variant="primary">Primary</Button>
+	<Button loading theme="outlined" variant="secondary">Secondary</Button>
+	<Button loading theme="outlined" variant="danger">Danger</Button>
+	<Button loading theme="outlined" variant="warning">Warning</Button>
+	<Button loading theme="outlined" variant="success">Success</Button>
+	<Button loading theme="outlined" variant="info">Info</Button>
+
+	<!-- Text -->
+	<Button loading theme="text">Default</Button>
+	<Button loading theme="text" variant="primary">Primary</Button>
+	<Button loading theme="text" variant="secondary">Secondary</Button>
+	<Button loading theme="text" variant="danger">Danger</Button>
+	<Button loading theme="text" variant="warning">Warning</Button>
+	<Button loading theme="text" variant="success">Success</Button>
+	<Button loading theme="text" variant="info">Info</Button>
+
+	<!-- Text Solid -->
+	<Button loading theme="text-solid">Default</Button>
+	<Button loading theme="text-solid" variant="primary">Primary</Button>
+	<Button loading theme="text-solid" variant="secondary">Secondary</Button>
+	<Button loading theme="text-solid" variant="danger">Danger</Button>
+	<Button loading theme="text-solid" variant="warning">Warning</Button>
+	<Button loading theme="text-solid" variant="success">Success</Button>
+	<Button loading theme="text-solid" variant="info">Info</Button>
 </template>
 ```
 

--- a/src/components/Button/index.scss
+++ b/src/components/Button/index.scss
@@ -60,10 +60,18 @@ $sizes: (
 			&.variant-#{$variantName} {
 				@if color.lightness($variantColor) < 80 {
 					color: $whiteColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $whiteColor;
+					}
 				}
 
 				@else {
 					color: $textColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $textColor;
+					}
 				}
 
 				background-color: $variantColor;
@@ -95,19 +103,35 @@ $sizes: (
 
 				@if color.lightness($variantColor) < 80 {
 					color: $variantColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $variantColor;
+					}
 				}
 
 				@else {
 					color: $textColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $textColor;
+					}
 				}
 
 				&:not(:disabled):hover {
 					@if color.lightness($variantColor) < 80 {
 						color: $whiteColor;
+
+						.mr-spinner .mr-spinner-item {
+							background-color: $whiteColor;
+						}
 					}
 
 					@else {
 						color: $textColor;
+
+						.mr-spinner .mr-spinner-item {
+							background-color: $textColor;
+						}
 					}
 
 					background-color: $variantColor;
@@ -131,10 +155,18 @@ $sizes: (
 			&.variant-#{$variantName} {
 				@if color.lightness($variantColor) < 80 {
 					color: $variantColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $variantColor;
+					}
 				}
 
 				@else {
 					color: $textColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $textColor;
+					}
 				}
 
 				&:not(:disabled):hover {
@@ -160,10 +192,18 @@ $sizes: (
 
 				@if color.lightness($variantColor) < 80 {
 					color: $variantColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $variantColor;
+					}
 				}
 
 				@else {
 					color: $textColor;
+
+					.mr-spinner .mr-spinner-item {
+						background-color: $textColor;
+					}
 				}
 
 				&:active,
@@ -189,5 +229,16 @@ $sizes: (
 		width: 24px;
 		height: 24px;
 		zoom: 0.7;
+	}
+
+	.mr-spinner {
+		position: absolute;
+		width: 18px;
+		height: 18px;
+		margin: 0;
+	}
+
+	&.is-loading {
+		color: transparent !important;
 	}
 }

--- a/src/components/Button/index.vue
+++ b/src/components/Button/index.vue
@@ -2,8 +2,10 @@
 	<button
 		class="mr-button"
 		:class="classes"
-		:disabled="disabled"
+		:disabled="disabled || loading"
 	>
+		<Spinner v-if="loading" />
+
 		<Icon
 			v-if="iconPosition === 'start' && icon !== ''"
 			:name="icon"
@@ -28,6 +30,7 @@
 import './index.scss'
 import 'remixicon/fonts/remixicon.css'
 import Icon from '../Icon/index.vue'
+import Spinner from '../Spinner/index.vue'
 
 export const themes = ['solid', 'outlined', 'text', 'text-solid']
 export const variants = ['default', 'primary', 'secondary', 'danger', 'warning', 'success', 'info']
@@ -37,7 +40,7 @@ export const iconPositions = ['start', 'end']
 export default {
 	name: 'Button',
 
-	components: { Icon },
+	components: { Icon, Spinner },
 
 	props: {
 		theme: {
@@ -78,11 +81,23 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		loading: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	computed: {
 		classes() {
-			return `${this.theme}-theme variant-${this.variant} size-${this.size}`
+			let classes = []
+
+			classes.push(`${this.theme}-theme`)
+			classes.push(`variant-${this.variant}`)
+			classes.push(`size-${this.size}`)
+			if (this.loading) classes.push('is-loading')
+
+			return classes.join(' ')
 		},
 
 		hasOnlyIcon() {

--- a/tests/unit/components/Button.spec.js
+++ b/tests/unit/components/Button.spec.js
@@ -1,5 +1,6 @@
 import Button from '@/components/Button'
 import Icon from '@/components/Icon'
+import Spinner from '@/components/Spinner'
 import { shallowMount } from '@vue/test-utils'
 
 describe('Button', () => {
@@ -72,24 +73,54 @@ describe('Button', () => {
 	})
 
 	describe('States', () => {
-		beforeEach(() => {
-			wrapper = shallowMount(Button, {
-				props: {
-					disabled: false,
-				},
+		describe('disabled', () => {
+			beforeEach(() => {
+				wrapper = shallowMount(Button, {
+					props: {
+						disabled: false,
+					},
+				})
+			})
+
+			it('button is not disabled when `disabled` prop is false', async () => {
+				expect(wrapper.find('button[disabled]').exists()).toBeFalsy()
+			})
+
+			it('sets the button as disabled when `disabled` prop is true', async () => {
+				expect(wrapper.find('button[disabled]').exists()).toBeFalsy()
+
+				await wrapper.setProps({ disabled: true })
+
+				expect(wrapper.find('button[disabled]').exists()).toBeTruthy()
 			})
 		})
 
-		it('button is not disabled when `disabled` prop is false', async () => {
-			expect(wrapper.find('button[disabled]').exists()).toBeFalsy()
-		})
+		describe('loading', () => {
+			beforeEach(() => {
+				wrapper = shallowMount(Button, {
+					props: {
+						loading: false,
+					},
+				})
+			})
 
-		it('sets the button as disabled when `disabled` prop is true', async () => {
-			expect(wrapper.find('button[disabled]').exists()).toBeFalsy()
+			it('button is not in loading state when `loading` prop is false', async () => {
+				expect(wrapper.find('button.is-loading').exists()).toBeFalsy()
+			})
 
-			await wrapper.setProps({ disabled: true })
+			it('sets the button as loading when `loading` prop is true', async () => {
+				expect(wrapper.find('button.is-loading').exists()).toBeFalsy()
 
-			expect(wrapper.find('button[disabled]').exists()).toBeTruthy()
+				await wrapper.setProps({ loading: true })
+
+				expect(wrapper.find('button.is-loading').exists()).toBeTruthy()
+			})
+
+			it('renders spinner component when button is in loading state', async () => {
+				await wrapper.setProps({ loading: true })
+
+				expect(wrapper.findComponent(Spinner).exists()).toBe(true)
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Description

Fixes #133 

Adds loading state prop to the button component

## Type of change

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] Improvement (non-breaking change that improves an existing feature)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Test coverage improvement

## How Has This Been Tested?

-   [x] Applies the is-loading class when loading prop is true
-   [x] Renders spinner component when loading prop is true

## Checklist:

|     | Task             | Description                                            |
| --- | ---------------- | ------------------------------------------------------ |
| ✅  | Unit Tests       | I have created unit tests for my changes               |
| ✅  | Documentation    | I have made corresponding changes to the documentation |
| ✅  | Self Code Review | I self-reviewed my code                                |
| ✅  | Warnings         | My changes generate no new warnings                    |

<sup>Use &nbsp; ✅ &nbsp; for marking the following items as done, and &nbsp;❌ &nbsp; to mark as not done</sup>
